### PR TITLE
Change URL package generated to fix error when trying to download

### DIFF
--- a/src/main/groovy/jython/util/PackageFinder.groovy
+++ b/src/main/groovy/jython/util/PackageFinder.groovy
@@ -51,7 +51,11 @@ class PackageFinder {
             it.name() == 'a' && it.text().equalsIgnoreCase("$name-${version}.tar.gz")
         }
 
-        new URL("$dir/${packageLink?.@href?.text()}").toURI().normalize().toURL()
+        if (!packageLink) {
+            throw new IllegalStateException('Could not download file')
+        }
+
+        new URL("${packageLink?.@href?.text()}").toURI().normalize().toURL()
     }
 
     static URL findPackageArchive(JythonPackage jythonPackage) {

--- a/src/test/groovy/jython/JythonPluginSpec.groovy
+++ b/src/test/groovy/jython/JythonPluginSpec.groovy
@@ -68,7 +68,7 @@ class JythonPluginSpec extends ProjectSpec {
         then:
         project.file("${project.buildDir}/jython/docutils-0.12.tar.gz").isFile()
 
-        1 * testLogger._({it =~ 'downloading https://pypi.python.org/packages/.*/docutils-0.12.tar.gz#md5=4622263b62c5c771c03502afa3157768'})
+        1 * testLogger._({it =~ 'downloading https://files.pythonhosted.org/packages/.*/docutils-0.12.tar.gz#sha256=c7db717810ab6965f66c8cf0398a98c9d8df982da39b4cd7f162911eb89596fa'})
         1 * testLogger._('Skipping existing file docutils-0.12.tar.gz')
     }
 


### PR DESCRIPTION
When trying to download a dependency the url generated is not found. It's due to an invalid url 

for example:

Downloading requests, version 2.10.0
inferred path is: https://pypi.python.org/simple/requests
downloading https://pypi.python.org/simple/requests/https:/files.pythonhosted.org/packages/49/6f/183063f01aae1e025cf0130772b55848750a2f3a89bfa11b385b35d7329d/requests-2.10.0.tar.gz#sha256=63f1815788157130cee16a933b2ee184038e975f0017306d723ac326b5525b54