### PR TITLE
upgrade Jython to 2.7.2 and  add 'src' subdirectories to runtime python classpath

### DIFF
--- a/src/main/groovy/jython/JythonPlugin.groovy
+++ b/src/main/groovy/jython/JythonPlugin.groovy
@@ -42,7 +42,7 @@ class JythonPlugin implements Plugin<Project> {
 			configurations { jython }
 
 			dependencies {
-				jython 'org.python:jython-standalone:2.7.0'
+				jython 'org.python:jython-standalone:2.7.2'
 			}
 
 			extensions.create('jython', JythonExtension, project)

--- a/src/main/groovy/jython/JythonTask.groovy
+++ b/src/main/groovy/jython/JythonTask.groovy
@@ -35,8 +35,21 @@ class JythonTask extends JavaExec {
 			logger.info project.configurations.pythonpath.asPath
 
 			systemProperties(['python.path': "${project.buildDir}/classes/main"
-							  + File.pathSeparator + "${project.buildDir}/classes/main/src"])
+								+ collectSrcDirectories(project.buildDir)
+			])
 			super.exec()
+		}
+
+		static String collectSrcDirectories(File buildDir) {
+			String path=''
+			if (buildDir.exists()) {
+				buildDir.eachDirRecurse { File dir ->
+					if (dir.name == 'src') {
+						path = path + File.pathSeparator + dir.absolutePath
+					}
+				}
+			}
+			return path
 		}
 
         void script (String script) {

--- a/src/test/groovy/jython/integration/JythonPluginIntegrationSpec.groovy
+++ b/src/test/groovy/jython/integration/JythonPluginIntegrationSpec.groovy
@@ -147,28 +147,11 @@ import requests_mock
 
     def "can import package with sources in src directory"(){
         given:
+            file('test.py').text = scriptWithImport('urllib3')
 
-            file('test.py').text=
-                    """
-import sys
-import urllib3
-
-
-print 'hello'
-"""
         when:
             buildFile << buildscript()
-            buildFile << '''
-            apply plugin:'com.github.rzabini.gradle-jython'
-
-            jython{
-                pypackage 'urllib3:1.24'
-            }
-
-            task testJython(type:jython.JythonTask) {
-                script file('test.py')
-            }
-        '''.stripIndent()
+            buildFile << buildWithPackage('urllib3', '1.24')
 
         and:
             executeGradleWrapper('clean', 'testJython')
@@ -176,6 +159,41 @@ print 'hello'
             notThrown(Exception)
     }
 
+    def "can import package with sources in src subdirectory"(){
+        given:
+            file('test.py').text = scriptWithImport('markupsafe')
+
+        when:
+            buildFile << buildscript()
+            buildFile << buildWithPackage('markupsafe', '1.1.1')
+
+        and:
+            executeGradleWrapper('clean', 'testJython')
+        then:
+            notThrown(Exception)
+    }
+
+    def scriptWithImport(String module) {
+        """
+import sys
+import ${module}
 
 
+print 'hello'
+"""
+    }
+
+    def buildWithPackage(String module, String version) {
+        """
+            apply plugin:'com.github.rzabini.gradle-jython'
+
+            jython{
+                pypackage '${module}:${version}'
+            }
+
+            task testJython(type:jython.JythonTask) {
+                script file('test.py')
+            }
+        """.stripIndent()
+    }
 }


### PR DESCRIPTION
feat: upgrade Jython to 2.7.2
fix: add 'src' subdirectories to runtime python classpath
